### PR TITLE
move io in initializer into the signature

### DIFF
--- a/lib/faastruby-spec-helper/src/modules/spec_helper.cr
+++ b/lib/faastruby-spec-helper/src/modules/spec_helper.cr
@@ -14,8 +14,7 @@ module FaaStRuby::SpecHelper
     property "headers"
     property "io"
     property "binary"
-    def initialize(@body : String?, @status : Int32, @headers : Hash(String, String), @binary : Bool = false)
-      @io = nil
+    def initialize(@body : String?, @status : Int32, @headers : Hash(String, String), @binary : Bool = false, @io : Bytes? = nil)
     end
 
     def initialize(@io : Bytes, @status : Int32, @headers : Hash(String, String), @binary : Bool = true)


### PR DESCRIPTION
The other initializer allows the setting of @io and this seems to simplify it.